### PR TITLE
Use full drive authz scope for drive uploads

### DIFF
--- a/mowgli_etl/cli/commands/drive_upload_command.py
+++ b/mowgli_etl/cli/commands/drive_upload_command.py
@@ -43,7 +43,7 @@ class DriveUploadCommand(_Command):
         self._logger.info("file uploaded %s", file)
 
     def __create_drive_client(self, service_account_file_path: Path):
-        scopes = ["https://www.googleapis.com/auth/drive.file"]
+        scopes = ["https://www.googleapis.com/auth/drive"]
         credentials = service_account.Credentials.from_service_account_file(
             service_account_file_path, scopes=scopes
         )


### PR DESCRIPTION
drive.file scope was not working anymore for an unknown reason